### PR TITLE
Support Terraform version >= 0.12.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.8.1
+  rev: v1.21.0
   hooks:
     - id: terraform_fmt
-    - id: terraform_docs
+    # - id: terraform_docs  # https://github.com/segmentio/terraform-docs/issues/62
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.1.0
+  rev: v2.4.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ See [DigitalOcean Pricing](https://www.digitalocean.com/pricing/) for costs.
 | image\_name | The image name or slug to lookup. | string | `ubuntu-18-04-x64` | no |
 | ipv6 | (Optional) Boolean controlling if IPv6 is enabled. Defaults to false. | string | `false` | no |
 | loadbalancer | Boolean to control whether to create a Load Balancer. | string | `false` | no |
-| loadbalancer\_algorithm | The load balancing algorithm used to determine which backend Droplet will be selected by a client. It must be either round_robin or least_connections. | string | `round_robin` | no |
-| loadbalancer\_forwarding\_rule | List of forwarding_rule maps to apply to the loadbalancer. | list | `[ { "entry_port": 80, "entry_protocol": "http", "target_port": 80, "target_protocol": "http" } ]` | no |
-| loadbalancer\_healthcheck | A healthcheck block to be assigned to the Load Balancer. Only 1 healthcheck is allowed. | map | `{ "path": "/", "port": 80, "protocol": "http" }` | no |
-| loadbalancer\_name | Override Load Balancer name. | string | `` | no |
-| loadbalancer\_redirect\_http\_to\_https | (Optional) A boolean value indicating whether HTTP requests to the Load Balancer on port 80 will be redirected to HTTPS on port 443. | string | `false` | no |
-| loadbalancer\_sticky\_sessions | A sticky_sessions block to be assigned to the Load Balancer. Only 1 sticky_sessions block is allowed. | map | `{}` | no |
-| loadbalancer\_tag | The name of a Droplet tag corresponding to Droplets to be assigned to the Load Balancer. | string | `` | no |
+| loadbalancer\_algorithm | The load balancing algorithm used to determine which backend Droplet will be selected by a client. It must be either round_robin or least_connections. | string | round_robin | no |
+| loadbalancer\_forwarding\_rule | List of forwarding_rule maps to apply to the loadbalancer. | map | `{ "entry_port": 80, "entry_protocol": "http", "target_port": 80, "target_protocol": "http", "tls_passthrough": false }` | no |
+| loadbalancer\_healthcheck | A healthcheck block to be assigned to the Load Balancer. Only 1 healthcheck is allowed. | map | `{ "check_interval_seconds": 10, "healthy_threshold": 5, "path": "/", "port": 80, "protocol": "http", "response_timeout_seconds": 10, "unhealthy_threshold": 3 }` | no |
+| loadbalancer\_name | Override Load Balancer name. | string |  | no |
+| loadbalancer\_redirect\_http\_to\_https | (Optional) A boolean value indicating whether HTTP requests to the Load Balancer on port 80 will be redirected to HTTPS on port 443. | string | false | no |
+| loadbalancer\_sticky\_sessions | A sticky_sessions block to be assigned to the Load Balancer. Only 1 sticky_sessions block is allowed. | map | `{ "type": "none" }` | no |
+| loadbalancer\_tag | The name of a Droplet tag corresponding to Droplets to be assigned to the Load Balancer. | string |  | no |
 | monitoring | (Optional) Boolean controlling whether monitoring agent is installed. Defaults to false. | string | `false` | no |
 | number\_format | The number format used to output. | string | `%02d` | no |
 | private\_domain | (Optional) String containing the private DNS domain to create a record for the Droplets in. | string | `` | no |

--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -44,7 +44,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| do\_token | - | string | - | yes |
+| do\_token |  | string | n/a | yes |
 
 ## Outputs
 

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -1,7 +1,7 @@
 variable "do_token" {}
 
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 // For testing purposes we create a random domain name to prevent clashing
@@ -25,14 +25,14 @@ resource "digitalocean_tag" "ROLE_web" {
 
 // DNS Zones
 resource "digitalocean_domain" "public" {
-  name = "${format("public.%s.com", random_string.domain.result)}"
+  name = format("public.%s.com", random_string.domain.result)
 }
 
 resource "digitalocean_record" "public-apex" {
-  domain = "${digitalocean_domain.public.name}"
+  domain = digitalocean_domain.public.name
   type   = "A"
   name   = "@"
-  value  = "${module.web.loadbalancer_ip}"
+  value  = module.web.loadbalancer_ip
 }
 
 module "web" {
@@ -42,11 +42,11 @@ module "web" {
 
   droplet_name = "example-web"
   droplet_size = "nano"
-  tags         = ["${digitalocean_tag.ENV_example.id}", "${digitalocean_tag.ROLE_web.id}"]
-  user_data    = "${file("user-data.web")}"
+  tags         = [digitalocean_tag.ENV_example.id, digitalocean_tag.ROLE_web.id]
+  user_data    = file("user-data.web")
 
   ipv6          = true
-  public_domain = "${digitalocean_domain.public.name}"
+  public_domain = digitalocean_domain.public.name
 
   loadbalancer = true
 }

--- a/examples/dns/output.tf
+++ b/examples/dns/output.tf
@@ -1,24 +1,24 @@
 output "loadbalancer_ip" {
   description = "IP address of the Load Balancer."
-  value       = "${module.web.loadbalancer_ip}"
+  value       = module.web.loadbalancer_ip
 }
 
 output "web_ipv4_address" {
   description = "List of IPv4 addresses of web Droplets."
-  value       = "${module.web.ipv4_address}"
+  value       = module.web.ipv4_address
 }
 
 output "web_ipv6_address" {
   description = "List of IPv6 addresses of web Droplets."
-  value       = "${module.web.ipv6_address}"
+  value       = module.web.ipv6_address
 }
 
 output "public_domain_name" {
   description = "The public DNS domain name."
-  value       = "${digitalocean_domain.public.name}"
+  value       = digitalocean_domain.public.name
 }
 
 output "public_hostnames" {
   description = "The public domain name of the first Droplet."
-  value       = "${module.web.public_a}"
+  value       = module.web.public_a
 }

--- a/examples/loadbalancer/README.md
+++ b/examples/loadbalancer/README.md
@@ -23,7 +23,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| do\_token | - | string | - | yes |
+| do\_token |  | string | n/a | yes |
 
 ## Outputs
 

--- a/examples/loadbalancer/main.tf
+++ b/examples/loadbalancer/main.tf
@@ -1,7 +1,7 @@
 variable "do_token" {}
 
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 resource "digitalocean_tag" "ENV_example" {
@@ -19,8 +19,8 @@ module "web" {
 
   droplet_name = "example-web"
   droplet_size = "nano"
-  tags         = ["${digitalocean_tag.ENV_example.id}", "${digitalocean_tag.ROLE_web.id}"]
-  user_data    = "${file("user-data.web")}"
+  tags         = [digitalocean_tag.ENV_example.id, digitalocean_tag.ROLE_web.id]
+  user_data    = file("user-data.web")
 
   loadbalancer = true
 }

--- a/examples/loadbalancer/output.tf
+++ b/examples/loadbalancer/output.tf
@@ -1,9 +1,9 @@
 output "loadbalancer_ip" {
   description = "IP address of the Load Balancer"
-  value       = "${module.web.loadbalancer_ip}"
+  value       = module.web.loadbalancer_ip
 }
 
 output "web_ipv4_address" {
   description = "List of IPv4 addresses of web Droplets"
-  value       = "${module.web.ipv4_address}"
+  value       = module.web.ipv4_address
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -20,7 +20,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| do\_token | - | string | - | yes |
+| do\_token |  | string | n/a | yes |
 
 ## Outputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,7 +1,7 @@
 variable "do_token" {}
 
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 resource "digitalocean_tag" "ENV_example" {
@@ -24,6 +24,6 @@ module "web" {
   ipv6               = true
   floating_ip        = true
   block_storage_size = 5
-  tags               = ["${digitalocean_tag.ENV_example.id}", "${digitalocean_tag.ROLE_web.id}"]
-  user_data          = "${file("user-data.web")}"
+  tags               = [digitalocean_tag.ENV_example.id, digitalocean_tag.ROLE_web.id]
+  user_data          = file("user-data.web")
 }

--- a/examples/simple/output.tf
+++ b/examples/simple/output.tf
@@ -1,29 +1,29 @@
 output "web_ids" {
   description = "List of IDs of web Droplets"
-  value       = "${module.web.droplet_id}"
+  value       = module.web.droplet_id
 }
 
 output "web_ipv4_address" {
   description = "List of IPv4 addresses of web Droplets"
-  value       = "${module.web.ipv4_address}"
+  value       = module.web.ipv4_address
 }
 
 output "web_ipv6_address" {
   description = "List of IPv6 addresses of web Droplets"
-  value       = "${module.web.ipv6_address}"
+  value       = module.web.ipv6_address
 }
 
 output "web_tags" {
   description = "List of tags of web Droplets"
-  value       = "${module.web.tags}"
+  value       = module.web.tags
 }
 
 output "web_volume_attachment_id" {
   description = "List of volume attachment IDs of web Droplets"
-  value       = "${module.web.volume_attachment_id}"
+  value       = module.web.volume_attachment_id
 }
 
 output "web_floating_ip_address" {
   description = "List of floating IP addresses of web Droplets"
-  value       = "${module.web.floating_ip_address}"
+  value       = module.web.floating_ip_address
 }

--- a/main.tf
+++ b/main.tf
@@ -15,124 +15,141 @@ locals {
 
 // Lookup image to get id
 data "digitalocean_image" "official" {
-  count = "${var.custom_image > 0 ? 0 : 1}"
-  slug  = "${var.image_name}"
+  count = var.custom_image == true ? 0 : 1
+  slug  = var.image_name
 }
 
 data "digitalocean_image" "custom" {
-  count = "${var.custom_image > 0 ? 1 : 0}"
-  name  = "${var.image_name}"
+  count = var.custom_image == true ? 1 : 0
+  name  = var.image_name
 }
 
 resource "digitalocean_tag" "default_tag" {
-  count = "${var.droplet_count > 0 ? 1 : 0}"
+  count = var.droplet_count > 0 ? 1 : 0
 
   name = "DEFAULT:${var.droplet_name}"
 }
 
 // Create Droplets
 resource "digitalocean_droplet" "droplet" {
-  count = "${var.droplet_count}"
+  count = var.droplet_count
 
-  image = "${coalesce(var.image_id, element(coalescelist(data.digitalocean_image.custom.*.image, data.digitalocean_image.official.*.image), 0))}"
-  name  = "${format("%s-%s", var.droplet_name, format(var.number_format, count.index+1))}"
+  image = coalesce(var.image_id, element(coalescelist(data.digitalocean_image.custom.*.image, data.digitalocean_image.official.*.image), 0))
+  name  = format("%s-%s", var.droplet_name, format(var.number_format, count.index + 1))
 
-  region = "${var.region}"
-  size   = "${coalesce(local.sizes[var.droplet_size], var.droplet_size)}"
+  region = var.region
+  size   = coalesce(local.sizes[var.droplet_size], var.droplet_size)
 
   // Optional
-  backups            = "${var.backups}"
-  monitoring         = "${var.monitoring}"
-  ipv6               = "${var.ipv6}"
-  private_networking = "${var.private_networking}"
-  ssh_keys           = "${var.ssh_keys}"
-  resize_disk        = "${var.resize_disk}"
-  tags               = ["${compact(concat(var.tags, list(digitalocean_tag.default_tag.id)))}"]
-  user_data          = "${var.user_data}"
+  backups            = var.backups
+  monitoring         = var.monitoring
+  ipv6               = var.ipv6
+  private_networking = var.private_networking
+  ssh_keys           = var.ssh_keys
+  resize_disk        = var.resize_disk
+  tags               = compact(concat(digitalocean_tag.default_tag.*.name, list("")))
+  user_data          = var.user_data
 }
-
 // Block storage
 resource "digitalocean_volume" "volume" {
-  count = "${var.block_storage_size > 0 ? coalesce(var.block_storage_count, var.droplet_count) : 0}"
+  count = var.block_storage_size > 0 ? coalesce(var.block_storage_count, var.droplet_count) : 0
 
-  region = "${var.region}"
-  name   = "${coalesce(var.block_storage_name, element(digitalocean_droplet.droplet.*.name, count.index))}"
-  size   = "${var.block_storage_size}"
+  region = var.region
+  name   = coalesce(var.block_storage_name, element(digitalocean_droplet.droplet.*.name, count.index))
+  size   = var.block_storage_size
 
   // Optional
   description              = "Block storage for ${element(digitalocean_droplet.droplet.*.name, count.index)}"
-  initial_filesystem_label = "${var.block_storage_filesystem_label}"
-  initial_filesystem_type  = "${var.block_storage_filesystem_type}"
+  initial_filesystem_label = var.block_storage_filesystem_label
+  initial_filesystem_type  = var.block_storage_filesystem_type
 }
 
 // Attach volumes
 resource "digitalocean_volume_attachment" "volume_attachment" {
-  count = "${var.block_storage_size > 0 && var.block_storage_attach > 0 ? coalesce(var.block_storage_count, var.droplet_count) : 0}"
+  count = var.block_storage_size > 0 && var.block_storage_attach == false ? coalesce(var.block_storage_count, var.droplet_count) : 0
 
-  droplet_id = "${element(digitalocean_droplet.droplet.*.id, count.index)}"
-  volume_id  = "${element(digitalocean_volume.volume.*.id, count.index)}"
+  droplet_id = element(digitalocean_droplet.droplet.*.id, count.index)
+  volume_id  = element(digitalocean_volume.volume.*.id, count.index)
 }
 
 // Floating IP
 resource "digitalocean_floating_ip" "floating_ip" {
-  count  = "${var.floating_ip > 0 && var.droplet_count > 0 ? coalesce(var.floating_ip_count, var.droplet_count) : 0}"
-  region = "${var.region}"
+  count  = var.floating_ip == true && var.droplet_count > 0 ? coalesce(var.floating_ip_count, var.droplet_count) : 0
+  region = var.region
 }
 
 // Floating IP assignment
 resource "digitalocean_floating_ip_assignment" "floating_ip_assignment" {
-  count = "${var.floating_ip > 0 && var.floating_ip_assign > 0 && var.droplet_count > 0 ? coalesce(var.floating_ip_count, var.droplet_count) : 0}"
+  depends_on = [digitalocean_droplet.droplet]
+  count      = var.floating_ip == true && var.floating_ip_assign == true && var.droplet_count > 0 ? coalesce(var.floating_ip_count, var.droplet_count) : 0
 
-  ip_address = "${element(digitalocean_floating_ip.floating_ip.*.id, count.index)}"
-  droplet_id = "${element(digitalocean_droplet.droplet.*.id, count.index)}"
+  ip_address = element(digitalocean_floating_ip.floating_ip.*.id, count.index)
+  droplet_id = element(digitalocean_droplet.droplet.*.id, count.index)
 }
 
 // Loadbalancer
 resource "digitalocean_loadbalancer" "loadbalancer" {
-  count = "${var.loadbalancer > 0 && var.droplet_count > 0 ? 1 : 0}"
+  count = var.loadbalancer == true && var.droplet_count > 0 ? 1 : 0
 
-  name      = "${coalesce(var.loadbalancer_name, format("%s-lb", var.droplet_name))}"
-  region    = "${var.region}"
-  algorithm = "${var.loadbalancer_algorithm}"
+  name      = coalesce(var.loadbalancer_name, format("%s-lb", var.droplet_name))
+  region    = var.region
+  algorithm = var.loadbalancer_algorithm
 
-  redirect_http_to_https = "${var.loadbalancer_redirect_http_to_https}"
+  redirect_http_to_https = var.loadbalancer_redirect_http_to_https
+  forwarding_rule {
+    entry_port      = lookup(var.loadbalancer_forwarding_rule, "entry_port")
+    entry_protocol  = lookup(var.loadbalancer_forwarding_rule, "entry_protocol")
+    target_port     = lookup(var.loadbalancer_forwarding_rule, "target_port")
+    target_protocol = lookup(var.loadbalancer_forwarding_rule, "target_protocol")
+    tls_passthrough = lookup(var.loadbalancer_forwarding_rule, "tls_passthrough")
+  }
+  healthcheck {
+    protocol                 = lookup(var.loadbalancer_healthcheck, "protocol")
+    port                     = lookup(var.loadbalancer_healthcheck, "port")
+    path                     = lookup(var.loadbalancer_healthcheck, "path")
+    check_interval_seconds   = lookup(var.loadbalancer_healthcheck, "check_interval_seconds")
+    response_timeout_seconds = lookup(var.loadbalancer_healthcheck, "response_timeout_seconds")
+    unhealthy_threshold      = lookup(var.loadbalancer_healthcheck, "unhealthy_threshold")
+    healthy_threshold        = lookup(var.loadbalancer_healthcheck, "healthy_threshold")
+  }
+  sticky_sessions {
+    type               = lookup(var.loadbalancer_sticky_sessions, "type")
+    cookie_name        = lookup(var.loadbalancer_sticky_sessions, "cookie_name")
+    cookie_ttl_seconds = lookup(var.loadbalancer_sticky_sessions, "cookie_ttl_seconds")
+  }
 
-  forwarding_rule = ["${var.loadbalancer_forwarding_rule}"]
-  healthcheck     = ["${var.loadbalancer_healthcheck}"]
-  sticky_sessions = ["${var.loadbalancer_sticky_sessions}"]
-
-  droplet_tag = "${digitalocean_tag.default_tag.name}"
+  droplet_tag = element(digitalocean_tag.default_tag.*.name, count.index)
 }
 
 // Public DNS A Record
 resource "digitalocean_record" "public_a" {
-  count = "${length(var.public_domain) > 0 ? var.droplet_count : 0}"
+  count = length(var.public_domain) > 0 ? var.droplet_count : 0
 
-  domain = "${var.public_domain}"
+  domain = var.public_domain
   type   = "A"
   ttl    = 60
-  name   = "${element(digitalocean_droplet.droplet.*.name, count.index)}"
-  value  = "${element(digitalocean_droplet.droplet.*.ipv4_address, count.index)}"
+  name   = element(digitalocean_droplet.droplet.*.name, count.index)
+  value  = element(digitalocean_droplet.droplet.*.ipv4_address, count.index)
 }
 
 // Public DNS AAAA Record
 resource "digitalocean_record" "public_aaaa" {
-  count = "${length(var.public_domain) > 0 ? var.droplet_count : 0}"
+  count = length(var.public_domain) > 0 ? var.droplet_count : 0
 
-  domain = "${var.public_domain}"
+  domain = var.public_domain
   type   = "AAAA"
   ttl    = 60
-  name   = "${element(digitalocean_droplet.droplet.*.name, count.index)}"
-  value  = "${element(digitalocean_droplet.droplet.*.ipv6_address, count.index)}"
+  name   = element(digitalocean_droplet.droplet.*.name, count.index)
+  value  = element(digitalocean_droplet.droplet.*.ipv6_address, count.index)
 }
 
 // Private DNS A Record
 resource "digitalocean_record" "private_a" {
-  count = "${var.private_networking > 0 && length(var.private_domain) > 0 ? var.droplet_count : 0}"
+  count = var.private_networking == true && length(var.private_domain) > 0 ? var.droplet_count : 0
 
-  domain = "${var.private_domain}"
+  domain = var.private_domain
   type   = "A"
   ttl    = 60
-  name   = "${element(digitalocean_droplet.droplet.*.name, count.index)}"
-  value  = "${element(digitalocean_droplet.droplet.*.ipv4_address_private, count.index)}"
+  name   = element(digitalocean_droplet.droplet.*.name, count.index)
+  value  = element(digitalocean_droplet.droplet.*.ipv4_address_private, count.index)
 }

--- a/output.tf
+++ b/output.tf
@@ -27,95 +27,95 @@ locals {
 
 output "droplet_id" {
   description = "List of IDs of Droplets"
-  value       = ["${local.droplet_id}"]
+  value       = local.droplet_id
 }
 
 output "droplet_ids" {
   description = "List of associated Droplet IDs of Volumes"
-  value       = ["${local.volume_droplet_ids}"]
+  value       = local.volume_droplet_ids
 }
 
 output "filesystem_type" {
   description = "List of initial filesystem types of Volumes"
-  value       = ["${local.volume_filesystem_type}"]
+  value       = local.volume_filesystem_type
 }
 
 output "floating_ip_address" {
   description = "List of floating IP addresses created"
-  value       = ["${local.floating_ip_address}"]
+  value       = local.floating_ip_address
 }
 
 output "image" {
   description = "List of images of Droplets"
-  value       = ["${local.droplet_image}"]
+  value       = local.droplet_image
 }
 
 output "ipv4_address" {
   description = "List of public IPv4 addresses assigned to the Droplets"
-  value       = ["${local.droplet_ipv4_address}"]
+  value       = local.droplet_ipv4_address
 }
 
 output "ipv4_address_private" {
   description = "List of private IPv4 addresses assigned to the Droplets, if applicable"
-  value       = ["${local.droplet_ipv4_address_private}"]
+  value       = local.droplet_ipv4_address_private
 }
 
 output "ipv6_address" {
   description = "List of public IPv6 addresses assigned to the Droplets, if applicable"
-  value       = ["${local.droplet_ipv6_address}"]
+  value       = local.droplet_ipv6_address
 }
 
 output "loadbalancer_id" {
   description = "ID of the loadbalancer"
-  value       = "${local.loadbalancer_id}"
+  value       = local.loadbalancer_id
 }
 
 output "loadbalancer_ip" {
   description = "IP address of the loadbalancer"
-  value       = "${local.loadbalancer_ip}"
+  value       = local.loadbalancer_ip
 }
 
 output "name" {
   description = "List of names of Droplets"
-  value       = ["${local.droplet_name}"]
+  value       = local.droplet_name
 }
 
 output "private_a" {
   description = "List of Droplet private DNS A record FQDNs."
-  value       = ["${local.private_a}"]
+  value       = local.private_a
 }
 
 output "public_a" {
   description = "List of Droplet public DNS A record FQDNs."
-  value       = ["${local.public_a}"]
+  value       = local.public_a
 }
 
 output "public_aaaa" {
   description = "List of Droplet public DNS AAAA record FQDNs."
-  value       = ["${local.public_aaaa}"]
+  value       = local.public_aaaa
 }
 
 output "region" {
   description = "List of regions of Droplets"
-  value       = ["${local.droplet_region}"]
+  value       = local.droplet_region
 }
 
 output "size" {
   description = "List of sizes of Droplets"
-  value       = ["${local.droplet_size}"]
+  value       = local.droplet_size
 }
 
 output "tags" {
   description = "List of tags of Droplets"
-  value       = ["${local.droplet_tags}"]
+  value       = local.droplet_tags
 }
 
 output "volume_attachment_id" {
   description = "List of IDs of Volume Attachments"
-  value       = ["${local.volume_attachment_id}"]
+  value       = local.volume_attachment_id
 }
 
 output "volume_id" {
   description = "List of IDs of Volumes"
-  value       = ["${local.volume_id}"]
+  value       = local.volume_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,10 @@ variable "droplet_count" {
 
 variable "droplet_name" {
   description = "The name of the droplet. If more than one droplet it is appended with the count, examples: stg-web, stg-web-01, stg-web-02"
-  type        = "string"
 }
 
 variable "droplet_size" {
   description = "the size slug of a droplet size"
-  type        = "string"
   default     = "micro"
 }
 
@@ -96,27 +94,27 @@ variable "loadbalancer_algorithm" {
 
 variable "loadbalancer_forwarding_rule" {
   description = "List of forwarding_rule maps to apply to the loadbalancer."
-  type        = "list"
 
-  default = [
-    {
-      entry_port     = 80
-      entry_protocol = "http"
-
-      target_port     = 80
-      target_protocol = "http"
-    },
-  ]
+  default = {
+    entry_port      = 80
+    entry_protocol  = "http"
+    target_port     = 80
+    target_protocol = "http"
+    tls_passthrough = false
+  }
 }
 
 variable "loadbalancer_healthcheck" {
   description = "A healthcheck block to be assigned to the Load Balancer. Only 1 healthcheck is allowed."
-  type        = "map"
 
   default = {
-    port     = 80
-    protocol = "http"
-    path     = "/"
+    port                     = 80
+    protocol                 = "http"
+    path                     = "/"
+    check_interval_seconds   = 10
+    response_timeout_seconds = 10
+    unhealthy_threshold      = 3
+    healthy_threshold        = 5
   }
 }
 
@@ -132,8 +130,11 @@ variable "loadbalancer_redirect_http_to_https" {
 
 variable "loadbalancer_sticky_sessions" {
   description = "A sticky_sessions block to be assigned to the Load Balancer. Only 1 sticky_sessions block is allowed."
-  type        = "map"
-  default     = {}
+  default = {
+    type               = "none"
+    cookie_name        = null
+    cookie_ttl_seconds = null
+  }
 }
 
 variable "loadbalancer_tag" {
@@ -168,13 +169,11 @@ variable "resize_disk" {
 
 variable "ssh_keys" {
   description = "(Optional) A list of SSH IDs or fingerprints to enable in the format [12345, 123456]. To retrieve this info, use a tool such as curl with the DigitalOcean API, to retrieve them."
-  type        = "list"
   default     = []
 }
 
 variable "tags" {
   description = "(Optional) A list of the tags to label this Droplet. A tag resource must exist before it can be associated with a Droplet."
-  type        = "list"
   default     = []
 }
 


### PR DESCRIPTION
This PR updates the module, its three examples, and the README to be compatible with the newer version of Terraform.

I've run it through the Terraform formatter (However, `terraform_docs` for `0.12.x`+ isn't [yet supported](https://github.com/segmentio/terraform-docs/issues/62)). I updated the README by hand for loadbalancer-related values. The DigitalOcean provider has likely changed since this module was released, and some inputs may have changed.

Let me know if there's any changes needed.

(This fixes  #3 )